### PR TITLE
Fixed a bug with sending embeds

### DIFF
--- a/SendEmbeds.plugin.js
+++ b/SendEmbeds.plugin.js
@@ -68,7 +68,7 @@ module.exports = class {
 	// Function that sends the embed
 	sendEmbed(embed) {
 		// Get the ID of the channel we want to send the embed
-		let channelID = BdApi.findModuleByProps("getLastSelectedChannelId").getChannelId();
+		let channelID = BdApi.findModuleByProps('getLastSelectedChannelId').getChannelId();
 
 		// Create the message
 		let MessageQueue = BdApi.findModuleByProps('enqueue');

--- a/SendEmbeds.plugin.js
+++ b/SendEmbeds.plugin.js
@@ -6,7 +6,7 @@
  * @website https://github.com/Fraserbc
  * @source https://github.com/Fraserbc/BetterDiscord-Embeds/blob/master/SendEmbeds.plugin.js
  */
- 
+
  const config = {
     info: {
         name: 'SendEmbeds',
@@ -60,7 +60,7 @@ module.exports = class {
 		this.handler = this.handleKeypress.bind(this);
 		let el = document.querySelectorAll('form[class^="form-');
 		if (el.length == 0) return;
-	
+
 		// Bind the handler
 		el[0].addEventListener('keydown', this.handler, false);
 	}
@@ -68,14 +68,14 @@ module.exports = class {
 	// Function that sends the embed
 	sendEmbed(embed) {
 		// Get the ID of the channel we want to send the embed
-		let channelID = BdApi.findModuleByProps('getChannelId').getChannelId();
-	
+		let channelID = BdApi.findModuleByProps("getLastSelectedChannelId").getChannelId();
+
 		// Create the message
 		let MessageQueue = BdApi.findModuleByProps('enqueue');
 		let MessageParser = BdApi.findModuleByProps('createBotMessage');
-	
+
 		let msg = MessageParser.createBotMessage(channelID, '');
-	
+
 		// Send the message
 		MessageQueue.enqueue({
 			type: 0,

--- a/SendEmbeds.plugin.js
+++ b/SendEmbeds.plugin.js
@@ -237,7 +237,6 @@ module.exports = class {
 		}
 
 		// Send the embed
-		console.log(this);
 		this.sendEmbed(discordEmbed);
 
 		this.lastKey = 0;


### PR DESCRIPTION
### Hello <img src="https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif" width="25px">
The error was related to retrieving the channel ID on which the user was sending the message. I fixed it in the first commit, and in the second one I removed the `console.log` command so it wouldn't clutter the console.

By the way, just a second ago I wanted to send embeds, and here the plugin doesn't work, so I'm coming with a fix ;D